### PR TITLE
redirect page opens in a different tab

### DIFF
--- a/src/templates/pages/openings.pug
+++ b/src/templates/pages/openings.pug
@@ -63,9 +63,9 @@ html(lang="en")
                                 .buttons
                                     form(action="form.html")
                                         button Apply now
-        section.vacancy(id='current-openings')
+        section.vacancy(id="current-openings")
             .heading
                 .section-line
                 h2 Live Vacancies
-                a(href='https://ft.wd3.myworkdayjobs.com/FT_External_Careers/9/refreshFacet/318c8bb6f553100021d223d9780d30be') See our current live roles here
+                a(href="https://ft.wd3.myworkdayjobs.com/FT_External_Careers/9/refreshFacet/318c8bb6f553100021d223d9780d30be" target="_blank") See our current live roles here
         include ../partials/footer.pug


### PR DESCRIPTION
Previously, Workday was opening on the same page, now it is opening up in a different tab.