### PR TITLE
Fix error with additionalRequirements variable

### DIFF
--- a/src/templates/pages/openings.pug
+++ b/src/templates/pages/openings.pug
@@ -54,7 +54,7 @@ html(lang="en")
                                             each line in requirements.list
                                                 p #{line}
                                 .list
-                                    - const additionalRequirements = opening.details.description.requirements
+                                    - const additionalRequirements = opening.details.description.additionalRequirements
                                     if additionalRequirements
                                         p.mini-header #{additionalRequirements.title}
                                             each line in additionalRequirements.list


### PR DESCRIPTION
Small error where `opening.details.description.requirements` should have been `opening.details.additionalRequirements`.