### PR TITLE
Use correct typographic characters

### DIFF
--- a/src/data.json
+++ b/src/data.json
@@ -1,7 +1,7 @@
 {
     "intro": {
-        "heading": "Make work that's meaningful",
-        "subheading": "We may be 130 years old but we've never stopped innovating...",
+        "heading": "Make work that’s meaningful",
+        "subheading": "We may be 130 years old but we've never stopped innovating…",
         "logo": "FT_Logo_PinkGrey.png",
         "heritage_logo": "ft-heritage-logo.svg"
     },


### PR DESCRIPTION
- Use a right curly quote (which is used elsewhere in the file but has been missed in the header)
- Use an ellipses character (…)

(Sorry I’m like this)