### PR TITLE
make email input type="email"

### DIFF
--- a/src/templates/pages/form.pug
+++ b/src/templates/pages/form.pug
@@ -25,7 +25,7 @@ html(lang="en")
                                     input.o-forms__text(type="text", id="last-name", placeholder="Last name", name="last-name" required)
 
                             label.o-forms__label(aria-describedby="text-box-info", for="email") Email address
-                            input.o-forms__text(type="text", id="email", placeholder="Enter your email address", name="email" required)
+                            input.o-forms__text(type="email", id="email", placeholder="Enter your email address", name="email" required)
 
                             fieldset.o-forms
                                 legend.o-forms__label(name="location", multiple)  Location


### PR DESCRIPTION
This makes the input `type="email"` this allows the browser to validate based on the presence of an `@` character.

https://developer.mozilla.org/en-US/docs/Web/HTML/Element/input/email