### PR TITLE
Use site URL for image host in production

### DIFF
--- a/src/templates/index.pug
+++ b/src/templates/index.pug
@@ -1,5 +1,5 @@
 - const origamiUrl = (url, quality) => `https://www.ft.com/__origami/service/image/v2/images/raw/${encodeURIComponent(url)}?source=roles&quality=${quality || 'low'}`
-- const imageHost = process.env.DEPLOY_PRIME_URL
+- const imageHost = (process.env.CONTEXT === 'production' ? process.env.URL  : process.env.DEPLOY_PRIME_URL)
 - const imageUrl = (url, quality) => (imageHost ? origamiUrl(`${imageHost}/${url}`, quality) : url)
 doctype html
 html(lang="en")


### PR DESCRIPTION
The `DEPLOY_PRIME_URL` is right for branch builds as it will let us see
images which haven't made it into production. In production though, we
should use the full URL rather than a Netlify URL.