### PR TITLE
Upgrade GitHub repos from master to main

### DIFF
--- a/README.md
+++ b/README.md
@@ -29,4 +29,4 @@ Run `npm run watch` to listen for file changes as you develop.
 
 ## Deploying changes
 
-Changes are deployed to Netlify. Ask in the #ft-next-dev channel on Slack if you need access to the Netlify dashboard. Preview your changes by using Netlify's Deploy Previews. It's a unique URL that is generated when you push any changes to GitHub. It allows you to test and verify your changes before merging them into the master branch. Once all GitHub checks have passed, the preview link will be available in the pull request.
+Changes are deployed to Netlify. Ask in the #ft-next-dev channel on Slack if you need access to the Netlify dashboard. Preview your changes by using Netlify's Deploy Previews. It's a unique URL that is generated when you push any changes to GitHub. It allows you to test and verify your changes before merging them into the main branch. Once all GitHub checks have passed, the preview link will be available in the pull request.


### PR DESCRIPTION
As an organisation we are moving away from the usage of `master` as a central branch and switching it to `main`, this is to avoid using unnecessary language that can be offensive. This PR is for making those changes.